### PR TITLE
v0 cft merge

### DIFF
--- a/marlin_cli/commands/install.py
+++ b/marlin_cli/commands/install.py
@@ -7,8 +7,9 @@ import tarfile
 import requests
 import shutil
 from marlin_cli.api import modules, archetypes
-from marlin_cli.util import yaml_merge
+from marlin_cli.util import cft_merge
 from marlin_cli.util import json_merge
+from marlin_cli.util import yaml_merge
 
 
 def update_project(module_install_conf):
@@ -21,7 +22,8 @@ def update_project(module_install_conf):
             case ".json":
                 json_merge(module_source, destination)
             case ".yaml" | ".yml":
-                yaml_merge(module_source, destination)
+                # handles cfts and regular yaml format
+                cft_merge(module_source, destination)
             case other:
                 click.echo(
                     click.style(

--- a/marlin_cli/util/cft_merge.py
+++ b/marlin_cli/util/cft_merge.py
@@ -1,27 +1,33 @@
 import click
 from cfn_tools import load_yaml, dump_yaml
 
+
 def cft_merge(source, destination):
     """
     Add source objects from a CFT to destination CFT
     """
     with open(source, "r") as s:
-      raw = s.read()
-      source_cft = load_yaml(raw)
+        raw = s.read()
+        source_cft = load_yaml(raw)
     with open(destination, "r") as d:
-      raw =  d.read()
-      destination_cft = load_yaml(raw)
-    
+        raw = d.read()
+        destination_cft = load_yaml(raw)
+
     if not destination_cft:
-        click.echo(click.style(f'Unable to parse yaml file. Ensure that it is properly formatted and try again.', fg='red'))
-        raise Exception('ParseException: Unable to parse yaml file.')
-    
+        click.echo(
+            click.style(
+                f"Unable to parse yaml file. Ensure that it is properly formatted and try again.",
+                fg="red",
+            )
+        )
+        raise Exception("ParseException: Unable to parse yaml file.")
+
     def item_gen(source, dest):
         if isinstance(source, dict):
             for key, val in source.items():
                 if not dest or key not in dest:
-                  dest[key] = val
-                
+                    dest[key] = val
+
                 item_gen(val, dest[key])
 
     item_gen(source_cft, destination_cft)

--- a/marlin_cli/util/cft_merge.py
+++ b/marlin_cli/util/cft_merge.py
@@ -1,16 +1,18 @@
-import yaml
-import click 
+import click
+from cfn_tools import load_yaml, dump_yaml
 
-def yaml_merge(source, destination):
+def cft_merge(source, destination):
     """
-    Add source json objects to destination yaml
+    Add source objects from a CFT to destination CFT
     """
     with open(source, "r") as s:
-        source_yaml = yaml.safe_load(s)
+      raw = s.read()
+      source_cft = load_yaml(raw)
     with open(destination, "r") as d:
-        destination_yaml = yaml.safe_load(d)
+      raw =  d.read()
+      destination_cft = load_yaml(raw)
     
-    if not destination_yaml:
+    if not destination_cft:
         click.echo(click.style(f'Unable to parse yaml file. Ensure that it is properly formatted and try again.', fg='red'))
         raise Exception('ParseException: Unable to parse yaml file.')
     
@@ -18,11 +20,11 @@ def yaml_merge(source, destination):
         if isinstance(source, dict):
             for key, val in source.items():
                 if not dest or key not in dest:
-                    dest[key] = val
+                  dest[key] = val
                 
                 item_gen(val, dest[key])
 
-    item_gen(source_yaml, destination_yaml)
+    item_gen(source_cft, destination_cft)
 
     with open(destination, "w") as d:
-        yaml.dump(destination_yaml, d, default_flow_style=False)
+        d.write(dump_yaml(destination_cft))

--- a/marlin_cli/util/yaml_merge.py
+++ b/marlin_cli/util/yaml_merge.py
@@ -1,5 +1,6 @@
 import yaml
-import click 
+import click
+
 
 def yaml_merge(source, destination):
     """
@@ -9,17 +10,22 @@ def yaml_merge(source, destination):
         source_yaml = yaml.safe_load(s)
     with open(destination, "r") as d:
         destination_yaml = yaml.safe_load(d)
-    
+
     if not destination_yaml:
-        click.echo(click.style(f'Unable to parse yaml file. Ensure that it is properly formatted and try again.', fg='red'))
-        raise Exception('ParseException: Unable to parse yaml file.')
-    
+        click.echo(
+            click.style(
+                f"Unable to parse yaml file. Ensure that it is properly formatted and try again.",
+                fg="red",
+            )
+        )
+        raise Exception("ParseException: Unable to parse yaml file.")
+
     def item_gen(source, dest):
         if isinstance(source, dict):
             for key, val in source.items():
                 if not dest or key not in dest:
                     dest[key] = val
-                
+
                 item_gen(val, dest[key])
 
     item_gen(source_yaml, destination_yaml)

--- a/poetry.lock
+++ b/poetry.lock
@@ -85,6 +85,23 @@ files = [
 ]
 
 [[package]]
+name = "cfn-flip"
+version = "1.3.0"
+description = "Convert AWS CloudFormation templates between JSON and YAML formats"
+category = "main"
+optional = false
+python-versions = "*"
+files = [
+    {file = "cfn_flip-1.3.0-py3-none-any.whl", hash = "sha256:faca8e77f0d32fb84cce1db1ef4c18b14a325d31125dae73c13bcc01947d2722"},
+    {file = "cfn_flip-1.3.0.tar.gz", hash = "sha256:003e02a089c35e1230ffd0e1bcfbbc4b12cc7d2deb2fcc6c4228ac9819307362"},
+]
+
+[package.dependencies]
+Click = "*"
+PyYAML = ">=4.1"
+six = "*"
+
+[[package]]
 name = "charset-normalizer"
 version = "3.0.1"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
@@ -570,6 +587,18 @@ testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-202
 testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+files = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+
+[[package]]
 name = "smmap"
 version = "5.0.0"
 description = "A pure Python implementation of a sliding window memory map manager"
@@ -622,4 +651,4 @@ test = ["covdefaults (>=2.2.2)", "coverage (>=7.1)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "3.11.1"
-content-hash = "096490429f536943c25830ce3b1fdf14bfd773bac53103821e5a201109066360"
+content-hash = "405b2d93f6e705dbdafe477975a5c9049fd4368314c92631851aa42c6f223fcc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ gitpython = "^3.1.30"
 requests = "^2.28.2"
 python-dotenv = "^0.21.1"
 pre-commit = "^3.0.4"
+cfn-flip = "^1.3.0"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
- Adds `cft_merge` capability using the [awslabs cfn_tools](https://github.com/awslabs/aws-cfn-template-flip/tree/master/cfn_tools)
    - These look like something that we could improve on in house (to handle certain cases), but not worth it right now IMO

**Note: ** `yaml` parsers don't like comments, so this removes them. Again, this is probably something we could get around by implementing our own `YamlLoader` and `YamlDumper`